### PR TITLE
Fix data persistence and service restart issues

### DIFF
--- a/AbnormalExitTracker.cs
+++ b/AbnormalExitTracker.cs
@@ -6,7 +6,7 @@ namespace ScreenTimeController;
 public static class AbnormalExitTracker
 {
     private static readonly string AbnormalExitFilePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
         "ScreenTimeController",
         "abnormal_exits.txt");
 
@@ -48,6 +48,12 @@ public static class AbnormalExitTracker
     {
         try
         {
+            string commonDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
+            if (!Directory.Exists(commonDataDir))
+            {
+                Directory.CreateDirectory(commonDataDir);
+            }
+
             string today = DateTime.Today.ToString("yyyy-MM-dd");
             File.WriteAllLines(AbnormalExitFilePath, new string[] { today, "0" });
         }

--- a/ProtectionService/Program.cs
+++ b/ProtectionService/Program.cs
@@ -50,7 +50,7 @@ namespace ProtectionService
             string? currentDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             _watchdogPath = Path.Combine(currentDir ?? "", "WatchdogMonitor.exe");
             _mainExePath = Path.Combine(currentDir ?? "", "ScreenTimeController.exe");
-            _logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController", "protection_service.log");
+            _logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController", "protection_service.log");
         }
 
         private void StartWorker()
@@ -72,6 +72,8 @@ namespace ProtectionService
 
         private void WorkerLoop()
         {
+            Thread.Sleep(5000);
+            
             while (_isRunning)
             {
                 try
@@ -161,8 +163,8 @@ namespace ProtectionService
                 Process[] processes = Process.GetProcessesByName(WatchdogProcessName);
                 if (processes.Length == 0)
                 {
-                    Log("WatchdogMonitor not running. Starting...");
-                    StartProcess(_watchdogPath);
+                    Log("WatchdogMonitor not running. Triggering scheduled task to start in user session...");
+                    TriggerScheduledTask();
                 }
                 else
                 {
@@ -213,18 +215,8 @@ namespace ProtectionService
 
                     if (shouldRestart)
                     {
-                        try
-                        {
-                            if (File.Exists(cleanExitFile))
-                            {
-                                File.Delete(cleanExitFile);
-                            }
-                        }
-                        catch { }
-
-                        Log("Main program not running and no clean exit. Starting...");
-                        RecordServiceRestart();
-                        StartProcess(_mainExePath);
+                        Log("Main program not running and no clean exit. Triggering watchdog restart...");
+                        TriggerWatchdogRestart();
                     }
                 }
                 else
@@ -241,21 +233,64 @@ namespace ProtectionService
             }
         }
 
-        private static void RecordServiceRestart()
+        private void TriggerWatchdogRestart()
         {
             try
             {
-                string logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController");
-                if (!Directory.Exists(logDir))
+                Process[] watchdogProcesses = Process.GetProcessesByName(WatchdogProcessName);
+                if (watchdogProcesses.Length == 0)
                 {
-                    Directory.CreateDirectory(logDir);
+                    Log("WatchdogMonitor not running. Triggering scheduled task to start in user session...");
+                    TriggerScheduledTask();
+                }
+                else
+                {
+                    Log("WatchdogMonitor already running. It will handle restart.");
+                    foreach (Process p in watchdogProcesses)
+                    {
+                        p.Dispose();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log($"Error triggering watchdog restart: {ex.Message}");
+            }
+        }
+
+        private static void TriggerScheduledTask()
+        {
+            try
+            {
+                using TaskService taskService = new();
+                Task? task = taskService.FindTask(TaskName);
+                if (task != null)
+                {
+                    task.Run();
+                    Log($"Triggered scheduled task: {TaskName}");
+                }
+                else
+                {
+                    Log("Scheduled task not found. Cannot trigger watchdog.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log($"Error triggering scheduled task: {ex.Message}");
+            }
+        }
+
+        private static void RecordAbnormalExit()
+        {
+            try
+            {
+                string commonDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
+                if (!Directory.Exists(commonDataDir))
+                {
+                    Directory.CreateDirectory(commonDataDir);
                 }
 
-                string serviceRestartFile = Path.Combine(logDir, "service_restart.txt");
-                string content = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
-                File.WriteAllText(serviceRestartFile, content);
-
-                string abnormalExitFile = Path.Combine(logDir, "abnormal_exits.txt");
+                string abnormalExitFile = Path.Combine(commonDataDir, "abnormal_exits.txt");
                 string today = DateTime.Today.ToString("yyyy-MM-dd");
                 int count = 0;
 
@@ -273,6 +308,14 @@ namespace ProtectionService
                             count = 1;
                         }
                     }
+                    else
+                    {
+                        count = 1;
+                    }
+                }
+                else
+                {
+                    count = 1;
                 }
 
                 File.WriteAllLines(abnormalExitFile, new string[] { today, count.ToString() });
@@ -280,7 +323,7 @@ namespace ProtectionService
             }
             catch (Exception ex)
             {
-                Log($"Error recording service restart: {ex.Message}");
+                Log($"Error recording abnormal exit: {ex.Message}");
             }
         }
 
@@ -450,8 +493,8 @@ namespace ProtectionService
                     Process[] watchdogProcesses = Process.GetProcessesByName(WatchdogProcessName);
                     if (watchdogProcesses.Length == 0)
                     {
-                        Log("WatchdogMonitor not running. Starting...");
-                        StartProcess(_watchdogPath);
+                        Log("WatchdogMonitor not running. Triggering scheduled task...");
+                        TriggerScheduledTask();
                     }
                     foreach (var p in watchdogProcesses) p.Dispose();
 
@@ -485,17 +528,7 @@ namespace ProtectionService
 
                         if (shouldRestart)
                         {
-                            try
-                            {
-                                if (File.Exists(cleanExitFile))
-                                {
-                                    File.Delete(cleanExitFile);
-                                }
-                            }
-                            catch { }
-
-                            Log("Main program not running and no clean exit (native mode). Starting...");
-                            StartProcess(_mainExePath);
+                            Log("Main program not running and no clean exit (native mode). Triggering watchdog restart...");
                         }
                     }
                     foreach (var p in mainProcesses) p.Dispose();
@@ -611,8 +644,8 @@ namespace ProtectionService
                         Process[] watchdogProcesses = Process.GetProcessesByName(WatchdogProcessName);
                         if (watchdogProcesses.Length == 0)
                         {
-                            Log("WatchdogMonitor not running. Starting...");
-                            StartProcess(_watchdogPath);
+                            Log("WatchdogMonitor not running. Triggering scheduled task...");
+                            TriggerScheduledTask();
                         }
                         foreach (var p in watchdogProcesses) p.Dispose();
 
@@ -646,17 +679,7 @@ namespace ProtectionService
 
                             if (shouldRestart)
                             {
-                                try
-                                {
-                                    if (File.Exists(cleanExitFile))
-                                    {
-                                        File.Delete(cleanExitFile);
-                                    }
-                                }
-                                catch { }
-
-                                Log("Main program not running and no clean exit (console mode). Starting...");
-                                StartProcess(_mainExePath);
+                                Log("Main program not running and no clean exit (console mode). Triggering watchdog restart...");
                             }
                         }
                         foreach (var p in mainProcesses) p.Dispose();

--- a/SettingsManager.cs
+++ b/SettingsManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 
 namespace ScreenTimeController;
 
@@ -90,8 +91,8 @@ public class SettingsManager
 
     public SettingsManager()
     {
-        _settingsFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController", "settings.txt");
-        _backupFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController", "settings_backup.txt");
+        _settingsFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController", "settings.txt");
+        _backupFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController", "settings_backup.txt");
         EnsureDirectory();
         LoadSettings();
     }
@@ -137,22 +138,39 @@ public class SettingsManager
 
     private void SafeWriteFile(string filePath, string content)
     {
-        string tempFile = filePath + ".tmp";
-        for (int i = 0; i < 5; i++)
+        string? directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            try { Directory.CreateDirectory(directory); } catch { }
+        }
+
+        for (int attempt = 0; attempt < 5; attempt++)
         {
             try
             {
+                string tempFile = filePath + ".tmp";
                 File.WriteAllText(tempFile, content, Encoding.UTF8);
+                
                 if (File.Exists(filePath))
                 {
                     File.Delete(filePath);
                 }
+                
                 File.Move(tempFile, filePath);
-                return;
+                
+                string verify = File.ReadAllText(filePath, Encoding.UTF8);
+                if (verify == content)
+                {
+                    return;
+                }
             }
             catch (IOException)
             {
-                System.Threading.Thread.Sleep(50);
+                Thread.Sleep(50);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Thread.Sleep(50);
             }
             catch
             {

--- a/TaskSchedulerManager.cs
+++ b/TaskSchedulerManager.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Security.Principal;
+using Microsoft.Win32.TaskScheduler;
+
+namespace ScreenTimeController;
+
+public static class TaskSchedulerManager
+{
+    private const string TaskName = "ScreenTimeController_Restart";
+    private const string TaskDescription = "Automatically restart Screen Time Controller when it exits unexpectedly";
+
+    public static bool IsAdministrator()
+    {
+        using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+        WindowsPrincipal principal = new(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+    }
+
+    public static bool IsTaskInstalled()
+    {
+        try
+        {
+            using TaskService taskService = new();
+            return taskService.FindTask(TaskName) != null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static (bool success, string message) InstallTaskWithMessage()
+    {
+        try
+        {
+            string? mainExePath = Process.GetCurrentProcess().MainModule?.FileName;
+            if (string.IsNullOrEmpty(mainExePath) || !mainExePath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                string? assemblyPath = Assembly.GetExecutingAssembly().Location;
+                if (!string.IsNullOrEmpty(assemblyPath))
+                {
+                    mainExePath = Path.ChangeExtension(assemblyPath, ".exe");
+                }
+            }
+            if (string.IsNullOrEmpty(mainExePath) || !File.Exists(mainExePath))
+            {
+                return (false, "Cannot determine executable path.");
+            }
+
+            string watchdogPath = Path.Combine(Path.GetDirectoryName(mainExePath)!, "WatchdogMonitor.exe");
+            if (!File.Exists(watchdogPath))
+            {
+                return (false, "WatchdogMonitor.exe not found.");
+            }
+
+            using TaskService taskService = new();
+            TaskDefinition taskDefinition = taskService.NewTask();
+            taskDefinition.RegistrationInfo.Description = TaskDescription;
+            taskDefinition.Settings.Enabled = true;
+            taskDefinition.Settings.Hidden = true;
+            taskDefinition.Settings.StartWhenAvailable = true;
+            taskDefinition.Settings.DisallowStartIfOnBatteries = false;
+            taskDefinition.Settings.StopIfGoingOnBatteries = false;
+            taskDefinition.Settings.ExecutionTimeLimit = TimeSpan.Zero;
+
+            taskDefinition.Triggers.Add(new BootTrigger { Delay = TimeSpan.FromSeconds(30) });
+            taskDefinition.Triggers.Add(new LogonTrigger { Delay = TimeSpan.FromSeconds(10) });
+            taskDefinition.Triggers.Add(new DailyTrigger { DaysInterval = 1, StartBoundary = DateTime.Today.AddMinutes(1) });
+
+            ExecAction execAction = new(watchdogPath);
+            taskDefinition.Actions.Add(execAction);
+
+            taskService.RootFolder.RegisterTaskDefinition(TaskName, taskDefinition);
+            return (true, "Task installed successfully.");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return (false, "Access denied. Please run as Administrator.");
+        }
+        catch (Exception ex)
+        {
+            LogError("InstallTask failed: " + ex.Message);
+            return (false, $"Failed to install task: {ex.Message}");
+        }
+    }
+
+    public static bool InstallTask()
+    {
+        return InstallTaskWithMessage().success;
+    }
+
+    public static (bool success, string message) UninstallTaskWithMessage()
+    {
+        try
+        {
+            using TaskService taskService = new();
+            taskService.RootFolder.DeleteTask(TaskName, false);
+            return (true, "Task uninstalled successfully.");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return (false, "Access denied. Please run as Administrator.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Failed to uninstall task: {ex.Message}");
+        }
+    }
+
+    public static bool EnsureTaskInstalled()
+    {
+        if (IsTaskInstalled())
+        {
+            return true;
+        }
+        return InstallTask();
+    }
+
+    public static bool RunTaskNow()
+    {
+        try
+        {
+            using TaskService taskService = new();
+            Task? task = taskService.FindTask(TaskName);
+            if (task == null)
+            {
+                return false;
+            }
+            task.Run();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void LogError(string message)
+    {
+        try
+        {
+            string logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
+            if (!Directory.Exists(logDir))
+            {
+                Directory.CreateDirectory(logDir);
+            }
+            string logPath = Path.Combine(logDir, "task_scheduler.log");
+            File.AppendAllText(logPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}{Environment.NewLine}");
+        }
+        catch { }
+    }
+}

--- a/TimeTracker.cs
+++ b/TimeTracker.cs
@@ -53,7 +53,7 @@ public class TimeTracker : IDisposable
         _settingsManager = settingsManager;
         _appUsage = new Dictionary<string, TimeSpan>();
         _bonusTime = TimeSpan.Zero;
-        _dataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController");
+        _dataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
         _usageFilePath = Path.Combine(_dataDirectory, "usage.txt");
         _appUsageFilePath = Path.Combine(_dataDirectory, "app_usage.txt");
         _backupFilePath = Path.Combine(_dataDirectory, "usage_backup.txt");
@@ -374,60 +374,67 @@ public class TimeTracker : IDisposable
 
     private void SaveAllData()
     {
-        try
+        for (int attempt = 0; attempt < 3; attempt++)
         {
-            SaveUsageData();
-            SaveAppUsageData();
+            try
+            {
+                SaveUsageData();
+                SaveAppUsageData();
+                return;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SaveAllData attempt {attempt + 1} failed: {ex.Message}");
+                Thread.Sleep(100);
+            }
         }
-        catch { }
     }
 
     private void SaveUsageData()
     {
-        try
+        string content;
+        lock (_lockObject)
         {
-            string content;
-            lock (_lockObject)
-            {
-                content = string.Format(CultureInfo.InvariantCulture,
-                    "{0:yyyy-MM-dd}|{1}|{2}",
-                    DateTime.Today,
-                    _totalUsage.TotalMinutes,
-                    _bonusTime.TotalMinutes);
-            }
-
-            if (File.Exists(_usageFilePath))
-            {
-                try
-                {
-                    File.Copy(_usageFilePath, _backupFilePath, true);
-                }
-                catch { }
-            }
-
-            SafeWriteFile(_usageFilePath, content);
+            content = string.Format(CultureInfo.InvariantCulture,
+                "{0:yyyy-MM-dd}|{1}|{2}",
+                DateTime.Today,
+                _totalUsage.TotalMinutes,
+                _bonusTime.TotalMinutes);
         }
-        catch { }
+
+        if (File.Exists(_usageFilePath))
+        {
+            try
+            {
+                File.Copy(_usageFilePath, _backupFilePath, true);
+            }
+            catch { }
+        }
+
+        SafeWriteFile(_usageFilePath, content);
+
+        string? verifyContent = SafeReadFile(_usageFilePath);
+        if (verifyContent != content)
+        {
+            throw new IOException("Verification failed for usage data");
+        }
     }
 
     private void SaveAppUsageData()
     {
-        try
+        string content;
+        lock (_lockObject)
         {
             StringBuilder sb = new();
             sb.AppendLine(DateTime.Today.ToString("yyyy-MM-dd"));
-
-            lock (_lockObject)
+            foreach (var kvp in _appUsage)
             {
-                foreach (var kvp in _appUsage)
-                {
-                    sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0}|{1}", kvp.Key, kvp.Value.TotalMinutes));
-                }
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0}|{1}", kvp.Key, kvp.Value.TotalMinutes));
             }
-
-            SafeWriteFile(_appUsageFilePath, sb.ToString());
+            content = sb.ToString();
         }
-        catch { }
+
+        SafeWriteFile(_appUsageFilePath, content);
     }
 
     public void Reset()
@@ -502,16 +509,30 @@ public class TimeTracker : IDisposable
 
     public void MarkCleanExit()
     {
-        try
+        for (int attempt = 0; attempt < 3; attempt++)
         {
-            string commonDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
-            if (!Directory.Exists(commonDataDir))
+            try
             {
-                Directory.CreateDirectory(commonDataDir);
+                string commonDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
+                if (!Directory.Exists(commonDataDir))
+                {
+                    Directory.CreateDirectory(commonDataDir);
+                }
+                
+                string content = DateTime.Today.ToString("yyyy-MM-dd");
+                SafeWriteFile(_cleanExitFilePath, content);
+                
+                string? verify = SafeReadFile(_cleanExitFilePath);
+                if (verify?.Trim() == content)
+                {
+                    return;
+                }
             }
-            SafeWriteFile(_cleanExitFilePath, DateTime.Today.ToString("yyyy-MM-dd"));
+            catch
+            {
+                Thread.Sleep(100);
+            }
         }
-        catch { }
     }
 
     public void Dispose()

--- a/WatchdogMonitor/Program.cs
+++ b/WatchdogMonitor/Program.cs
@@ -81,7 +81,7 @@ namespace WatchdogMonitor
             {
                 try
                 {
-                    string logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController");
+                    string logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
                     if (!Directory.Exists(logDir))
                     {
                         Directory.CreateDirectory(logDir);
@@ -294,13 +294,13 @@ namespace WatchdogMonitor
         {
             try
             {
-                string logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController");
-                if (!Directory.Exists(logDir))
+                string commonDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
+                if (!Directory.Exists(commonDataDir))
                 {
-                    Directory.CreateDirectory(logDir);
+                    Directory.CreateDirectory(commonDataDir);
                 }
 
-                string abnormalExitFile = Path.Combine(logDir, "abnormal_exits.txt");
+                string abnormalExitFile = Path.Combine(commonDataDir, "abnormal_exits.txt");
                 string today = DateTime.Today.ToString("yyyy-MM-dd");
                 int count = 0;
 
@@ -341,7 +341,7 @@ namespace WatchdogMonitor
         {
             try
             {
-                string logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ScreenTimeController");
+                string logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ScreenTimeController");
                 if (!Directory.Exists(logDir))
                 {
                     Directory.CreateDirectory(logDir);


### PR DESCRIPTION
- Fix path mismatch: all components now use CommonApplicationData
- Fix service startup timeout: add 5s delay before worker starts
- Fix service cannot start GUI process: use scheduled task instead
- Fix duplicate abnormal exit records: only WatchdogMonitor records
- Fix clean_exit.txt incorrectly deleted: remove deletion from ProtectionService
- Add TaskSchedulerManager for scheduled task management
- Update all log paths to CommonApplicationData